### PR TITLE
Make --cached option as a switch

### DIFF
--- a/src/cmd/packages.rs
+++ b/src/cmd/packages.rs
@@ -45,7 +45,7 @@ pub struct ArgsList {
     board: Option<String>,
 
     /// only show the cached list
-    #[argh(option)]
+    #[argh(switch)]
     cached: bool,
 
     /// glob pattern of the packages


### PR DESCRIPTION
Commit 6635370 ("Add packages list subcommand") introduced --cached option as an option must be set. But it should be a switching option so that it can be disabled by default.