### PR TITLE
flash: Use the board name for looking up version

### DIFF
--- a/src/cmd/flash.rs
+++ b/src/cmd/flash.rs
@@ -102,7 +102,7 @@ pub fn run(args: &Args) -> Result<()> {
     {
         args.version.clone()
     } else {
-        lookup_full_version(&args.version)?
+        lookup_full_version(&args.version, &board)?
     };
     if host == "local" && version != "latest" {
         return Err(anyhow!(

--- a/src/cmd/sync.rs
+++ b/src/cmd/sync.rs
@@ -49,7 +49,7 @@ pub fn run(args: &Args) -> Result<()> {
         if args.version == "tot" {
             args.version.clone()
         } else {
-            lookup_full_version(&args.version)?
+            lookup_full_version(&args.version, "eve")?
         }
     } else {
         lookup_arc_version(&args.version)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn list_gs_files(pattern: &str) -> Result<String> {
         .to_string())
 }
 
-fn lookup_full_version(input: &str) -> Result<String> {
+fn lookup_full_version(input: &str, board: &str) -> Result<String> {
     let input = input.trim();
     let re_cros_version_without_milestone = regex!(r"^\d+\.\d+\.\d+$");
     let re_cros_version = regex!(r"/(R\d+\-\d+\.\d+\.\d+)/");
@@ -46,7 +46,8 @@ fn lookup_full_version(input: &str) -> Result<String> {
     } else if re_cros_version_without_milestone.is_match(input) {
         VERSION_TO_MILESTONE_CACHE.get_or_else(input, &|key| {
             let output = list_gs_files(&format!(
-                "gs://chromeos-image-archive/eve-release/R*-{}/chromiumos_test_image.tar.xz",
+                "gs://chromeos-image-archive/{}-release/R*-{}/chromiumos_test_image.tar.xz",
+                board,
                 key
             ))
             .context("gsutil command failed (maybe you need depot_tools and/or `gsutil.py config` with 'chromeos-swarming' project)")?;


### PR DESCRIPTION
Use the board name instead of "eve" for looking up version. 'lium sync' will continue use "eve".