### PR TITLE
Fix help messages for the top level commands.

### DIFF
--- a/src/cmd/arc.rs
+++ b/src/cmd/arc.rs
@@ -13,7 +13,7 @@ use lium::repo::get_repo_dir;
 use std::process::Command;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// DUT controller
+/// control ARC
 #[argh(subcommand, name = "arc")]
 pub struct Args {
     #[argh(subcommand)]

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -11,7 +11,7 @@ use lium::chroot::Chroot;
 use lium::repo::get_repo_dir;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// build a package
+/// build package(s)
 #[argh(subcommand, name = "build")]
 pub struct Args {
     /// target cros repo dir

--- a/src/cmd/chroot.rs
+++ b/src/cmd/chroot.rs
@@ -11,7 +11,7 @@ use lium::dut::SshInfo;
 use lium::repo::get_repo_dir;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// cros_sdk wrapper
+/// run in chroot
 #[argh(subcommand, name = "chroot")]
 pub struct Args {
     /// target cros repo dir

--- a/src/cmd/cl.rs
+++ b/src/cmd/cl.rs
@@ -17,7 +17,7 @@ lazy_static! {
 }
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// CL (Change List) helpers
+/// manage CL (Change List)
 #[argh(subcommand, name = "cl")]
 pub struct Args {
     #[argh(subcommand)]

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -9,7 +9,7 @@ use argh::FromArgs;
 use lium::config::Config;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// DUT controller
+/// configure lium
 #[argh(subcommand, name = "config")]
 pub struct Args {
     #[argh(subcommand)]

--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -14,7 +14,7 @@ use lium::repo::get_repo_dir;
 use regex_macro::regex;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// cros deploy wrapper
+/// deploy package(s)
 #[argh(subcommand, name = "deploy")]
 pub struct Args {
     /// target cros repo dir

--- a/src/cmd/dut.rs
+++ b/src/cmd/dut.rs
@@ -28,7 +28,7 @@ use std::time;
 use termion::screen::IntoAlternateScreen;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// DUT controller
+/// control DUT
 #[argh(subcommand, name = "dut")]
 pub struct Args {
     #[argh(subcommand)]

--- a/src/cmd/flash.rs
+++ b/src/cmd/flash.rs
@@ -16,7 +16,7 @@ use regex::Regex;
 use std::process::Command;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// Flash CrOS images
+/// flash image
 #[argh(subcommand, name = "flash")]
 pub struct Args {
     /// flash to a USB stick

--- a/src/cmd/packages.rs
+++ b/src/cmd/packages.rs
@@ -11,7 +11,7 @@ use lium::chroot::Chroot;
 use lium::repo::get_repo_dir;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// Tast test wrapper
+/// manage modified package(s)
 #[argh(subcommand, name = "packages")]
 pub struct Args {
     #[argh(subcommand)]

--- a/src/cmd/servo.rs
+++ b/src/cmd/servo.rs
@@ -21,7 +21,7 @@ use std::fs::read_to_string;
 use std::process;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// DUT controller
+/// control Servo
 #[argh(subcommand, name = "servo")]
 pub struct Args {
     #[argh(subcommand)]

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -25,7 +25,7 @@ use lium::util::run_bash_command;
 use std::fs;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// DUT controller
+/// setup development environment
 #[argh(subcommand, name = "setup")]
 pub struct Args {
     #[argh(subcommand)]

--- a/src/cmd/sync.rs
+++ b/src/cmd/sync.rs
@@ -19,7 +19,7 @@ use std::fs;
 use std::path::Path;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// smart repo sync wrapper
+/// synchronize repository
 #[argh(subcommand, name = "sync")]
 pub struct Args {
     /// target cros repo dir. If omitted, current directory will be used.

--- a/src/cmd/tast.rs
+++ b/src/cmd/tast.rs
@@ -17,7 +17,7 @@ use lium::dut::SshInfo;
 use lium::repo::get_repo_dir;
 
 #[derive(FromArgs, PartialEq, Debug)]
-/// Tast test wrapper
+/// run Tast test
 #[argh(subcommand, name = "tast")]
 pub struct Args {
     #[argh(subcommand)]


### PR DESCRIPTION
The help messages are changed to (1) use the imperative form, and (2) provide the intuition of subcommands available. For (2), it does not try to cover all the subcommands. Instead, it aims to provide a hint to the user to figure out which command to further look into.

It now prints:
```
Usage: lium <command> [<args>]

yet another wrapper for CrOS developers. For more information, see: https://chromium.googlesource.com/chromiumos/platform/dev-util/+/refs/heads/main/contrib/lium/ . For Googlers, see go/lium and go/lium-bug

Options:
  --help            display usage information

Commands:
  arc               control ARC
  build             build package(s)
  cl                manage CL (Change List)
  chroot            run in chroot
  config            configure lium
  deploy            deploy package(s)
  dut               control DUT
  flash             flash image
  packages          manage modified package(s)
  servo             control Servo
  setup             setup development environment
  sync              synchronize repository
  tast              run Tast test
  version           display version info
```

I didn't touch the first paragraph (yet anther ...), although it feels slightly outdated. @hikalium if you want me to change that in this PR, please suggest a text that you want to have.