### PR TITLE
repo: don't try to print repo when empty

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -117,6 +117,10 @@ pub fn repo_sync(repo: &str, force: bool) -> Result<()> {
                 .split('\n')
                 .skip_while(|e| !e.contains("Failing repos:"));
             let repos: Vec<String> = it.map(|e| e.to_string()).collect();
+            if repos.is_empty() {
+                println!("{stderr}");
+                return Err(anyhow!("repo sync failed (please check the above message)"));
+            }
             let repos = repos[1..=repos.len() - 2].to_owned();
             println!("Failed repos: {:?}", &repos);
             if !force {


### PR DESCRIPTION
With this, lium will output something like below for my case.

```
Syncing /usr/local/google/home/hidenorik/chromiumos to R117-15572.32.0 ...
Previous CROS version was: R116-15506.0.0
Running repo init with the given version...
repo: reusing existing repo client checkout in /usr/local/google/home/hidenorik/chromiumos

repo has been initialized in /usr/local/google/home/hidenorik/chromiumos
Running repo sync...
repo sync failed.
Updating depot_tools...
depot_tools update failed. Conflict in /usr/local/google/home/hidenorik/local/src/depot_tools
error: Your local changes to the following files would be overwritten by checkout:
        repo_launcher
Please commit your changes or stash them before you switch branches.
Aborting
Traceback (most recent call last):
  File "/usr/local/google/home/hidenorik/local/src/depot_tools/repo", line 55, in <module>
    sys.exit(main(sys.argv[1:]))
             ^^^^^^^^^^^^^^^^^^
  File "/usr/local/google/home/hidenorik/local/src/depot_tools/repo", line 49, in main
    _UpdateDepotTools()
  File "/usr/local/google/home/hidenorik/local/src/depot_tools/repo", line 39, in _UpdateDepotTools
    subprocess.run([UPDATE_DEPOT_TOOLS], check=True)
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '[PosixPath('/usr/local/google/home/hidenorik/local/src/depot_tools/update_depot_tools')]' returned non-zero exit status 1.
Error: repo sync failed (please check the above message)
```