### PR TITLE
Stacked: Add a rustfmt.toml file with some clean guidlines.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+tab_spaces = 4
+fn_args_layout = "Tall"
+format_strings = true
+use_try_shorthand = true
+wrap_comments = true
+max_width = 100

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -81,7 +81,8 @@ impl Chroot {
     ///
     /// # Arguments
     ///
-    /// * `name` - A filename-capable identifier for the script (this file will be created automatically)
+    /// * `name` - A filename-capable identifier for the script (this file will
+    ///   be created automatically)
     /// * `script` - One or more lines of bash script
     /// * `args` - args to be passed to the script
     pub fn run_bash_script_in_chroot(

--- a/src/cmd/cl.rs
+++ b/src/cmd/cl.rs
@@ -42,7 +42,8 @@ pub struct ArgsPick {
     #[argh(option)]
     repo: Option<String>,
 
-    /// dir to run git commands, relative to cros checkout (e.g. src/platform/crosvm)
+    /// dir to run git commands, relative to cros checkout (e.g.
+    /// src/platform/crosvm)
     #[argh(option)]
     dir: String,
 

--- a/src/cmd/dut.rs
+++ b/src/cmd/dut.rs
@@ -211,7 +211,8 @@ struct ArgsDutShell {
     #[argh(switch)]
     autologin: bool,
 
-    /// if specified, run the command on dut and exit. if not, it will open an interactive shell.
+    /// if specified, run the command on dut and exit. if not, it will open an
+    /// interactive shell.
     #[argh(positional)]
     args: Vec<String>,
 }
@@ -334,7 +335,8 @@ fn is_ccd_opened(cr50: &LocalServo) -> Result<bool> {
 fn do_rma_auth(cr50: &LocalServo) -> Result<()> {
     // Get rma_auth_challenge first, to get the code correctly
     let rma_auth_challenge = cr50.run_cmd("Shell", "rma_auth")?;
-    // Try ccd open first since pre-MP devices may be able to open ccd without rma_auth
+    // Try ccd open first since pre-MP devices may be able to open ccd without
+    // rma_auth
     cr50.run_cmd("Shell", "ccd open")?;
     for _ in 0..3 {
         // Generate rma_auth URL to unlock and abort
@@ -432,9 +434,13 @@ fn set_dev_gbb_flags(repo: &str, cr50: &LocalServo) -> Result<()> {
     )?;
     chroot.run_bash_script_in_chroot(
         "write gbb flags",
-        &format!("sudo flashrom -p raiden_debug_spi:target=AP,serial={} -w -i GBB:/tmp/gbb2.bin --noverify-all", cr50.serial()),
-        None
-        )?;
+        &format!(
+            "sudo flashrom -p raiden_debug_spi:target=AP,serial={} -w -i GBB:/tmp/gbb2.bin \
+             --noverify-all",
+            cr50.serial()
+        ),
+        None,
+    )?;
     Ok(())
 }
 
@@ -455,9 +461,13 @@ fn reset_gbb_flags(repo: &str, cr50: &LocalServo) -> Result<()> {
     )?;
     chroot.run_bash_script_in_chroot(
         "write gbb flags",
-        &format!("sudo flashrom -p raiden_debug_spi:target=AP,serial={} -w -i GBB:/tmp/gbb2.bin --noverify-all", cr50.serial()),
-        None
-        )?;
+        &format!(
+            "sudo flashrom -p raiden_debug_spi:target=AP,serial={} -w -i GBB:/tmp/gbb2.bin \
+             --noverify-all",
+            cr50.serial()
+        ),
+        None,
+    )?;
     Ok(())
 }
 fn is_ccd_testlab_enabled(cr50: &LocalServo) -> Result<bool> {
@@ -478,7 +488,11 @@ fn enable_ccd_testlab(servo: &LocalServo) -> Result<()> {
         .run_cmd("Shell", "ccd testlab")
         .context(anyhow!("Failed to run `ccd testlab` command"))?;
     if !result.trim().contains("CCD test lab mode enabled") {
-        return Err(anyhow!("CCD testlab mode is disabled. Please run `minicom -w -D {}` and run `ccd testlab enable` on it and follow the instructions.", cr50.tty_path("Shell")?));
+        return Err(anyhow!(
+            "CCD testlab mode is disabled. Please run `minicom -w -D {}` and run `ccd testlab \
+             enable` on it and follow the instructions.",
+            cr50.tty_path("Shell")?
+        ));
     }
     Ok(())
 }
@@ -516,7 +530,8 @@ fn check_dev_gbb_flags(dut: &DutInfo) -> Result<()> {
 /// "Ready for development" means:
 /// - CCD (Closed Case Debugging) is in "Open" state
 /// - A Servo is attached correctly
-/// - At least one Ethernet connection is available (so MAC addr and an IP address is known)
+/// - At least one Ethernet connection is available (so MAC addr and an IP
+///   address is known)
 /// - GBB flags are set to 0x19
 /// - CCD testlab mode is enabled
 #[argh(subcommand, name = "setup")]
@@ -553,11 +568,16 @@ fn run_setup(args: &ArgsSetup) -> Result<()> {
     let repo = get_repo_dir(&args.repo)?;
     let servo = if let Some(serial) = &args.serial {
         let list = ServoList::discover()?;
-        list.find_by_serial(serial).context(format!("
+        list.find_by_serial(serial)
+            .context(format!(
+                "
         Servo {serial} not found.
-        Please check the servo connection, try another side of USB port, attach servo directly with a host instead of via hub, etc...
+        Please check the servo connection, try another side of USB port, attach servo directly \
+                 with a host instead of via hub, etc...
         `lium servo list` may be helpful.
-        "))?.clone()
+        "
+            ))?
+            .clone()
     } else {
         let list = ServoList::discover()?;
         let list: Vec<LocalServo> = list
@@ -567,7 +587,10 @@ fn run_setup(args: &ArgsSetup) -> Result<()> {
             .cloned()
             .collect();
         if list.len() != 1 {
-            return Err(anyhow!("Please specify --serial when multiple Servo is connected. `lium servo list` may be helpful."));
+            return Err(anyhow!(
+                "Please specify --serial when multiple Servo is connected. `lium servo list` may \
+                 be helpful."
+            ));
         }
         list.first()
             .context(
@@ -636,7 +659,8 @@ fn run_dut_do(args: &ArgsDutDo) -> Result<()> {
         .collect();
     if !unknown_actions.is_empty() || args.actions.is_empty() {
         return Err(anyhow!(
-            "Unknown action: {unknown_actions:?}. See `lium dut do --list-actions` for available actions."
+            "Unknown action: {unknown_actions:?}. See `lium dut do --list-actions` for available \
+             actions."
         ));
     }
     let dut = &SshInfo::new(args.dut.as_ref().context(anyhow!("Please specify --dut"))?)?;
@@ -771,10 +795,12 @@ fn run_dut_list(args: &ArgsDutList) -> Result<()> {
 /// show DUT info
 #[argh(subcommand, name = "info")]
 struct ArgsDutInfo {
-    /// DUT identifiers (e.g. 127.0.0.1, localhost:2222, droid_NXHKDSJ003138124257611)
+    /// DUT identifiers (e.g. 127.0.0.1, localhost:2222,
+    /// droid_NXHKDSJ003138124257611)
     #[argh(option)]
     dut: String,
-    /// comma-separated list of attribute names. to show the full list, try `lium dut info --keys ?`
+    /// comma-separated list of attribute names. to show the full list, try
+    /// `lium dut info --keys ?`
     #[argh(positional)]
     keys: Vec<String>,
 }
@@ -808,7 +834,8 @@ pub struct ArgsDiscover {
     /// if not specified, the first interface in the routing table will be used.
     #[argh(option)]
     interface: Option<String>,
-    /// remote machine to do the scan. If not specified, run the discovery locally.
+    /// remote machine to do the scan. If not specified, run the discovery
+    /// locally.
     #[argh(option)]
     remote: Option<String>,
     /// path to a list of DUT_IDs to scan.

--- a/src/cmd/flash.rs
+++ b/src/cmd/flash.rs
@@ -15,8 +15,9 @@ use regex::Regex;
 use std::process::Command;
 
 /// Determine a BOARD to flash, based on the parameters.
-/// If arg_dut is specified, this function will check if the board given via args is
-/// compatible with the BOARD of an image which is currently installed on the DUT.
+/// If arg_dut is specified, this function will check if the board given via
+/// args is compatible with the BOARD of an image which is currently installed
+/// on the DUT.
 fn determine_board_to_flash(
     arg_dut: &Option<String>,
     arg_board: &Option<String>,
@@ -53,7 +54,12 @@ fn determine_board_to_flash(
             };
             let cap_dut = re.captures(&board_from_dut).unwrap();
             if cap_arg[1] != cap_dut[1] {
-                return Err(anyhow!("Given BOARD does not match with DUT: {} is given but {} is installed on the DUT", board_from_arg, board_from_dut));
+                return Err(anyhow!(
+                    "Given BOARD does not match with DUT: {} is given but {} is installed on the \
+                     DUT",
+                    board_from_arg,
+                    board_from_dut
+                ));
             }
             Ok(board_from_arg)
         }
@@ -101,7 +107,8 @@ pub struct Args {
     enable_rootfs_verification: bool,
 }
 pub fn run(args: &Args) -> Result<()> {
-    // repo path is needed since cros flash outside chroot only works within the cros checkout
+    // repo path is needed since cros flash outside chroot only works within the
+    // cros checkout
     let repo = &get_repo_dir(&args.repo)?;
 
     let image_path = if let Some(image) = &args.image {
@@ -116,7 +123,8 @@ pub fn run(args: &Args) -> Result<()> {
         } else {
             "remote"
         };
-        // if version is not specified on the command line, it will be set to "latest" by argh
+        // if version is not specified on the command line, it will be set to "latest"
+        // by argh
         let version = if &args.version == "latest"
             || &args.version == "latest-dev"
             || &args.version == "latest-official"

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -76,7 +76,8 @@ fn run_bash_completion(_args: &ArgsBashCompletion) -> Result<()> {
     .status
     .exit_ok()?;
     eprintln!(
-        "Installed ~/.lium/lium.bash and an entry in ~/.bash_completion. Please run `source ~/.bash_completion` for the current shell."
+        "Installed ~/.lium/lium.bash and an entry in ~/.bash_completion. Please run `source \
+         ~/.bash_completion` for the current shell."
     );
     Ok(())
 }

--- a/src/dut.rs
+++ b/src/dut.rs
@@ -357,7 +357,10 @@ impl DutInfo {
                 }
             }
         }
-        let cmds = format!("function lium_get_default_iface {{ {CMD_GET_DEFAULT_IFACE} ; }} && export -f lium_get_default_iface && ");
+        let cmds = format!(
+            "function lium_get_default_iface {{ {CMD_GET_DEFAULT_IFACE} ; }} && export -f \
+             lium_get_default_iface && "
+        );
         let cmds = cmds
             + &keys_from_dut
                 .iter()
@@ -686,10 +689,11 @@ impl SshInfo {
         return Err(anyhow!("Could not find a port available for forwarding"));
     }
     /// Keep forwarding in background.
-    /// The execution will be blocked until the first attemp succeeds, and the return value
-    /// represents which port is used for this forwarding, or an error.
-    /// Forwarding port on this side will be automatically determined by start_ssh_forwarding,
-    /// and the same port will be used for reconnecting while this lium instance is running.
+    /// The execution will be blocked until the first attemp succeeds, and the
+    /// return value represents which port is used for this forwarding, or an
+    /// error. Forwarding port on this side will be automatically determined by
+    /// start_ssh_forwarding, and the same port will be used for reconnecting
+    /// while this lium instance is running.
     pub fn start_ssh_forwarding_range_background(&self, port_range: Range<u16>) -> Result<u16> {
         let (mut child, port) = block_on(self.start_ssh_forwarding_range(port_range))?;
         let ssh = self.clone();
@@ -891,8 +895,11 @@ pub fn discover_local_nodes(iface: Option<String>) -> Result<Vec<String>> {
         })
         .context("Failed to determine interface to scan")?;
     eprintln!("Using {iface} to scan...");
-    let output = run_bash_command(&format!(
-        "ping6 -c 3 -I {iface} ff02::1 | grep 'bytes from' | cut -d ' ' -f 4 | tr -d ',' | sort | uniq"),
+    let output = run_bash_command(
+        &format!(
+            "ping6 -c 3 -I {iface} ff02::1 | grep 'bytes from' | cut -d ' ' -f 4 | tr -d ',' | \
+             sort | uniq"
+        ),
         None,
     )?;
     let stdout = get_stdout(&output);

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,10 @@ static VERSION_TO_MILESTONE_CACHE: KvCache<String> = KvCache::new("version_cache
 fn list_gs_files(pattern: &str) -> Result<String> {
     let cmd = format!("gsutil.py ls {}", pattern.trim());
     println!("{:?}", cmd);
-    let output = Command::new("bash")
-        .arg("-c")
-        .arg(cmd)
-        .output()
-        .context("Failed to execute gsutil ls (maybe you need depot_tools and/or `gsutil.py config` with 'chromeos-swarming' project)")?;
+    let output = Command::new("bash").arg("-c").arg(cmd).output().context(
+        "Failed to execute gsutil ls (maybe you need depot_tools and/or `gsutil.py config` with \
+         'chromeos-swarming' project)",
+    )?;
     Ok(String::from_utf8_lossy(&output.stdout)
         .to_string()
         .trim()
@@ -47,10 +46,12 @@ fn lookup_full_version(input: &str, board: &str) -> Result<String> {
         VERSION_TO_MILESTONE_CACHE.get_or_else(input, &|key| {
             let output = list_gs_files(&format!(
                 "gs://chromeos-image-archive/{}-release/R*-{}/chromiumos_test_image.tar.xz",
-                board,
-                key
+                board, key
             ))
-            .context("gsutil command failed (maybe you need depot_tools and/or `gsutil.py config` with 'chromeos-swarming' project)")?;
+            .context(
+                "gsutil command failed (maybe you need depot_tools and/or `gsutil.py config` with \
+                 'chromeos-swarming' project)",
+            )?;
             let output = re_cros_version
                 .captures(output.trim())
                 .context("Invalid gsutil output")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,8 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-//! This module is used to get Linux System Base (LSB) release information on Chrome OS systems, as
-//! usually located in `/etc/lsb-release`.
+//! This module is used to get Linux System Base (LSB) release information on
+//! Chrome OS systems, as usually located in `/etc/lsb-release`.
 
 //! This file is a fork of:
 //! https://source.chromium.org/chromium/chromiumos/platform2/+/main:vm_tools/crostini_client/lsb_release.rs;drc=41a92137d3e795ad6a51c5dec90dfa142af8c7c3
@@ -39,7 +39,8 @@ impl Error for LsbReleaseError {}
 /// A result from gathering resource information.
 pub type LsbReleaseResult<T> = Result<T, LsbReleaseError>;
 
-/// Release information typically gathered from the environment or from `/etc/lsb-release`.
+/// Release information typically gathered from the environment or from
+/// `/etc/lsb-release`.
 #[derive(Debug)]
 pub struct LsbRelease {
     info: BTreeMap<String, String>,
@@ -51,8 +52,8 @@ impl LsbRelease {
         self.info.get(k.as_ref()).map(|s| s.as_str())
     }
 
-    /// Gets the type of release channel this release information corresponds to,
-    /// or none if this
+    /// Gets the type of release channel this release information corresponds
+    /// to, or none if this
     /// information was not indicated.
     pub fn release_channel(&self) -> Option<ReleaseChannel> {
         self.get(CHROMEOS_RELEASE_TRACK_KEY).map(|c| c.into())
@@ -93,8 +94,8 @@ impl FromStr for LsbRelease {
     }
 }
 
-/// A channel of OS releases. Channels are distinguished by their relative stability and frequency
-/// of release.
+/// A channel of OS releases. Channels are distinguished by their relative
+/// stability and frequency of release.
 #[derive(PartialEq, Eq, Debug)]
 pub enum ReleaseChannel<'a> {
     Lts,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -72,7 +72,8 @@ pub fn get_repo_dir(dir: &Option<String>) -> Result<String> {
 
 pub fn get_current_synced_version(repo: &str) -> Result<String> {
     ensure_if_cros_dir(repo)?;
-    let cmd = "./src/third_party/chromiumos-overlay/chromeos/config/chromeos_version.sh | grep -e VERSION_STRING -e CHROME_BRANCH | cut -d '=' -f 2 | cut -d '-' -f 1";
+    let cmd = "./src/third_party/chromiumos-overlay/chromeos/config/chromeos_version.sh | grep -e \
+               VERSION_STRING -e CHROME_BRANCH | cut -d '=' -f 2 | cut -d '-' -f 1";
     let output = run_bash_command(cmd, Some(repo))?;
     let binding = get_stdout(&output);
     let output: Vec<&str> = binding.split('\n').collect();
@@ -87,7 +88,8 @@ pub fn get_current_synced_version(repo: &str) -> Result<String> {
 
 pub fn get_current_synced_arc_version(repo: &str) -> Result<String> {
     // TODO: Are there any better way to do?
-    let cmd = "cd .repo/manifests && git branch -r --contains HEAD | xargs -n 1 | grep m/ | sed -E 's@m/(.*)-arc@\\1@g'";
+    let cmd = "cd .repo/manifests && git branch -r --contains HEAD | xargs -n 1 | grep m/ | sed \
+               -E 's@m/(.*)-arc@\\1@g'";
     let output = run_bash_command(cmd, Some(repo))?;
     Ok(get_stdout(&output))
 }

--- a/src/servo.rs
+++ b/src/servo.rs
@@ -388,7 +388,10 @@ impl LocalServo {
         let socat_path = run_bash_command("which socat", None)?;
         let socat_path = get_stdout(&socat_path);
         if socat_path.trim().is_empty() {
-            return Err(anyhow!("socat not found. Please install socat with something like: `sudo apt install socat`"));
+            return Err(anyhow!(
+                "socat not found. Please install socat with something like: `sudo apt install \
+                 socat`"
+            ));
         }
         if !fs::metadata(tty_path)?.file_type().is_char_device() {
             return Err(anyhow!("{tty_path} is not a char device"));
@@ -617,7 +620,14 @@ pub struct ServodConnection {
 }
 impl ServodConnection {
     pub fn from_serial(serial: &str) -> Result<Self> {
-        let output = run_bash_command(&format!("ps ax | grep /servod | grep -e '-s {}' | grep -E -o -e '-p [0-9]+' | cut -d ' ' -f 2", serial), None);
+        let output = run_bash_command(
+            &format!(
+                "ps ax | grep /servod | grep -e '-s {}' | grep -E -o -e '-p [0-9]+' | cut -d ' ' \
+                 -f 2",
+                serial
+            ),
+            None,
+        );
         if let Ok(output) = output {
             let stdout = get_stdout(&output);
             let port = stdout.parse::<u16>()?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,8 +34,8 @@ pub fn has_root_privilege() -> Result<bool> {
         .context("Failed to get current uid")?;
     Ok(get_stdout(&output).trim() == "0")
 }
-/// Usage of this should be minimized, to avoid environment variable related issues.
-/// Current use cases are:
+/// Usage of this should be minimized, to avoid environment variable related
+/// issues. Current use cases are:
 /// - Resetting servo by writing to sysfs
 pub fn run_lium_with_sudo(args: &[&str]) -> Result<()> {
     let mut c = Command::new("sudo");


### PR DESCRIPTION
This is based on my own rustfmt.toml I usually use. I tend to set these for the following reasons:

imports_granularity = "Crate" # this combines a bunch of lines at the top, but it doesnt match google style so I removed it
tab_spaces = 2 # param lists and chained calls tend to be longer and more common in rust, I think this increases readability
fn_args_layout = "Tall" # this is way easier to read than non tall
format_strings = true
use_try_shorthand = true # replace any ugly try! macros with the pretty ?
wrap_comments = true
max_width = 100 # If we can do it in Java, we can do it in Rust

<!-- ps-id: 10da94ec-c786-4b1c-97d7-5a95e4df1fa4 -->