### PR TITLE
Fix for reading subcommand inputs and processing.

### DIFF
--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -114,15 +114,18 @@ impl Chroot {
         info!("Running {name} in chroot...");
 
         let mut result = String::new();
-        launch_command_with_stdout_label_and_process(
+        let status = launch_command_with_stdout_label_and_process(
             &mut cmd,
             format!("chroot command: {name}").into(),
-            Some(|stdout: CommandOutputReciever, _| {
+            Some(|outputs: CommandOutputReciever| {
+                let stdout = outputs.stdout_only();
                 result = stdout.collect::<Vec<String>>().join("\n");
                 Ok(())
             }),
         )
         .context(anyhow!("wait_with_output_failed. cmd = {cmd:?}"))?;
+
+        info!("chroot process exited with exit code: {status}");
 
         Ok(result)
     }

--- a/src/util/shell_helpers.rs
+++ b/src/util/shell_helpers.rs
@@ -20,6 +20,7 @@ use futures::AsyncBufReadExt;
 use itertools::EitherOrBoth;
 use itertools::Itertools;
 use tracing::info;
+use tracing::trace;
 use wait_timeout::ChildExt;
 
 pub fn get_stdout(output: &Output) -> String {
@@ -116,18 +117,17 @@ pub fn launch_command_with_stdout_label(
     c: &mut Command,
     attempted_command_name_summary: Option<String>,
 ) -> Result<ExitStatus> {
-    launch_command_with_stdout_label_and_process::<fn(_, _) -> _>(
+    launch_command_with_stdout_label_and_process::<fn(_) -> _>(
         c,
         attempted_command_name_summary,
         None,
     )
 }
 
-/// Input to the process function of
-/// [launch_command_with_stdout_label_and_process] which can be iterated on to
-/// get the stdout and stderr of the process for processing.
-pub type CommandOutputReciever = std::sync::mpsc::IntoIter<String>;
-
+/// An iterator container for stdout and stderr that will always pull the next
+/// values even if unused, so that the process can continue.
+///
+/// Without this, the process will block if the stdout or stderr is not read.
 /// Launch a command surrounded by labels to make it easier to find in logs.
 /// It also prepends stderr with stderr in the logs.
 ///
@@ -138,7 +138,7 @@ pub fn launch_command_with_stdout_label_and_process<F>(
     process: Option<F>,
 ) -> Result<ExitStatus>
 where
-    F: FnOnce(CommandOutputReciever, CommandOutputReciever) -> Result<()>,
+    F: FnOnce(CommandOutputReciever) -> Result<()>,
 {
     // Make sure to pipe stderr/out up to this process for logging.
     c.stdout(Stdio::piped()).stderr(Stdio::piped());
@@ -175,45 +175,172 @@ where
     // Create channels to copy the stdout and stderr to.
     let (stdout_snd, stdout_rcv) = std::sync::mpsc::sync_channel(1);
     let (stderr_snd, stderr_rcv) = std::sync::mpsc::sync_channel(1);
-    let join = std::thread::spawn(move || {
-        for pair in stdout_iter.zip_longest(stderr_iter) {
-            match pair {
-                EitherOrBoth::Both(stdout, stderr) => {
-                    let stdout = stdout.unwrap();
-                    let stderr = stderr.unwrap();
-                    info!("{}", stdout.clone());
-                    stdout_snd.send(stdout).unwrap();
+    let join = spawn_output_reader_thread(stdout_iter, stderr_iter, stdout_snd, stderr_snd);
 
-                    info!("stderr: {}", stderr.clone());
-                    stderr_snd.send(stderr).unwrap();
-                }
-                EitherOrBoth::Left(stdout) => {
+    // Read the recieving ends of the channels and pass them to the process
+    // function's input.
+    if let Some(process) = process {
+        // create a tracing span for the process function.
+        let _process_span = tracing::trace_span!("process stdout/err").entered();
+
+        process(CommandOutputReciever::new(
+            stdout_rcv.into_iter(),
+            stderr_rcv.into_iter(),
+        ))?;
+    }
+
+    // Wait for the process to finish, then wait for the thread to finish reading
+    // stdout/err.
+    let r = child.wait()?;
+    info!("Subprocess {executable} finished with exit code {r}");
+
+    join.join()
+        .map_err(|e| anyhow!("could not join stdout/err logging and copy thread: {e:?}"))?;
+    trace!("stdout/err logging and copy thread joined");
+
+    Ok(r)
+}
+
+/// This function creates a thread that reads the stdout and stderr of a sub
+/// command and logs them, forwarding a copy to the channels.
+///
+/// This is a little complex because in order to continue with a fixed size
+/// channel, once one is exhausted it needs to be closed. This is why instead of
+/// a single for loop over the iterator, there is a while let until one of
+/// stdout or stderr is exhausted, then the corresponding channel is closed and
+/// the other is drained.
+fn spawn_output_reader_thread<IOut, IErr>(
+    stdout_iter: IOut,
+    stderr_iter: IErr,
+    stdout_snd: std::sync::mpsc::SyncSender<String>,
+    stderr_snd: std::sync::mpsc::SyncSender<String>,
+) -> std::thread::JoinHandle<()>
+where
+    IOut: Iterator<Item = std::io::Result<String>> + Send + 'static,
+    IErr: Iterator<Item = std::io::Result<String>> + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let _stdout_stderr_output_reader_span =
+            tracing::trace_span!("subprocess output reader").entered();
+
+        // Iterate until one of stdout or stderr is exhausted.
+        let mut cmd_outputs_iter = stdout_iter.zip_longest(stderr_iter);
+        let mut curr = cmd_outputs_iter.next();
+        while let Some(EitherOrBoth::Both(stdout, stderr)) = curr {
+            let stdout = stdout.unwrap();
+            let stderr = stderr.unwrap();
+            info!("{}", stdout.clone());
+            stdout_snd.send(stdout).unwrap();
+
+            info!("stderr: {}", stderr.clone());
+            stderr_snd.send(stderr).unwrap();
+
+            curr = cmd_outputs_iter.next();
+        }
+
+        // Close the corresponding channel, and drain the other iterator.
+        match curr {
+            Some(EitherOrBoth::Left(_)) => {
+                drop(stderr_snd);
+                while let Some(EitherOrBoth::Left(stdout)) = cmd_outputs_iter.next() {
                     let stdout = stdout.unwrap();
                     info!("{}", stdout.clone());
                     stdout_snd.send(stdout).unwrap();
                 }
-                EitherOrBoth::Right(stderr) => {
+            }
+            Some(EitherOrBoth::Right(_)) => {
+                drop(stdout_snd);
+                while let Some(EitherOrBoth::Right(stderr)) = cmd_outputs_iter.next() {
                     let stderr = stderr.unwrap();
                     info!("stderr: {}", stderr.clone());
                     stderr_snd.send(stderr).unwrap();
                 }
             }
+            Some(EitherOrBoth::Both(_, _)) => panic!("somehow a stdout or stderr came back alive!"),
+            None => (), // We're done.
         }
-    });
+    })
+}
 
-    // Read the recieving ends of the channels and pass them to the process
-    // function's input.
-    if let Some(process) = process {
-        let stdout_iter = stdout_rcv.into_iter();
-        let stderr_iter = stderr_rcv.into_iter();
-        process(stdout_iter, stderr_iter)?;
+pub struct CommandOutputReciever {
+    stdout_iter: std::sync::mpsc::IntoIter<String>,
+    stderr_iter: std::sync::mpsc::IntoIter<String>,
+}
+
+pub struct CommandOutputStdOutReciever {
+    command_output_reciever: CommandOutputReciever,
+}
+
+pub struct CommandOutputStdErrReciever {
+    command_output_reciever: CommandOutputReciever,
+}
+
+impl CommandOutputReciever {
+    fn new(
+        stdout_iter: std::sync::mpsc::IntoIter<String>,
+        stderr_iter: std::sync::mpsc::IntoIter<String>,
+    ) -> Self {
+        Self {
+            stdout_iter,
+            stderr_iter,
+        }
     }
 
-    join.join()
-        .map_err(|_| anyhow!("could not join stdout/err logging and copy thread"))?;
-    let r = child.wait()?;
+    pub fn stdout_only(self) -> CommandOutputStdOutReciever {
+        CommandOutputStdOutReciever {
+            command_output_reciever: self,
+        }
+    }
 
-    info!("Subprocess {executable} finished with exit code {r}");
+    pub fn stderr_only(self) -> CommandOutputStdErrReciever {
+        CommandOutputStdErrReciever {
+            command_output_reciever: self,
+        }
+    }
+}
 
-    Ok(r)
+impl Iterator for CommandOutputReciever {
+    type Item = (Option<String>, Option<String>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let stdout = self.stdout_iter.next();
+        let stderr = self.stderr_iter.next();
+        if stdout.is_some() || stderr.is_some() {
+            return Some((stdout, stderr));
+        }
+
+        None
+    }
+}
+
+impl Iterator for CommandOutputStdOutReciever {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (stdout, _) = self.command_output_reciever.next()?;
+
+        if stdout.is_none() {
+            // Exhaust the iterator and return None.
+            for _ in self.command_output_reciever.by_ref() {}
+            return None;
+        }
+
+        stdout
+    }
+}
+
+impl Iterator for CommandOutputStdErrReciever {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (_, stderr) = self.command_output_reciever.next()?;
+
+        if stderr.is_none() {
+            // Exhaust the iterator and return None.
+            for _ in self.command_output_reciever.by_ref() {}
+            return None;
+        }
+
+        stderr
+    }
 }


### PR DESCRIPTION
With a split in loops, the iterators are always able to continue without
blocking the main thread.
