### PR TITLE
Update scripts/deploy_release.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ build:
 	@rustup -q which rustc > /dev/null || { echo "Please install rustup via https://rustup.rs/" ; exit 1 ; }
 	RUSTFLAGS=$(RUSTFLAGS) cargo build --target x86_64-unknown-linux-gnu
 
+release_build:
+	@rustup -q which rustc > /dev/null || { echo "Please install rustup via https://rustup.rs/" ; exit 1 ; }
+	RUSTFLAGS=$(RUSTFLAGS) cargo build --release --target x86_64-unknown-linux-gnu
+
 install:
 	@rustup -q which rustc > /dev/null || { echo "Please install rustup via https://rustup.rs/" ; exit 1 ; }
 	RUSTFLAGS=$(RUSTFLAGS) cargo install --target x86_64-unknown-linux-gnu --path .

--- a/scripts/deploy_release.sh
+++ b/scripts/deploy_release.sh
@@ -1,32 +1,54 @@
-#/bin/bash -e
+#!/usr/bin/env bash
 # Copyright 2023 The ChromiumOS Authors
 #
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
-TMPDIR=`mktemp -d`
-if ! [ -z "$(git status --porcelain)" ]; then
-	echo "Uncommited changes found. Please commit the change first."
+
+cd "$(dirname ${BASH_SOURCE[0]})"
+cd ..
+echo "Project root directory is: `pwd`"
+
+echo "Checking authentications..."
+gh auth status || gh auth login
+cargo owner --list || cargo login
+
+cargo test
+make release_build
+
+VERSION=`cargo run --release -- version | cut -d ' ' -f 2 | grep -E '[0-9]+\.[0-9]+\.[0-9]'`
+PROJECT_PATH=`dirname -- $(cargo locate-project --message-format plain)`
+BINPATH=`readlink -f ${PROJECT_PATH}/target/x86_64-unknown-linux-gnu/release/lium`
+file ${BINPATH}
+ldd ${BINPATH} | grep 'statically linked'
+
+if gh release list | grep ${VERSION} ; then
+	# Release with the version found. Quit.
+	echo "release with the same version on GitHub is found. Please delete the version first by running:"
+	echo "gh release delete -y ${VERSION}"
 	exit 1
 fi
+echo "Testing and releasing ${VERSION}"
+
+if ! [ -z "$(git status --porcelain)" ]; then
+	echo "Uncommited changes found. Please commit and upload the changes first."
+	exit 1
+fi
+
 if ! git status | grep 'up to date' ; then
 	echo "Remote branch is not up to date. Please push the commits first."
 	exit 1
 fi
-cargo test --target-dir ${TMPDIR}
-cargo build --release --target-dir ${TMPDIR}
-VERSION=`${TMPDIR}/release/lium version | cut -d ' ' -f 2`
 
-if gh release list | grep ${VERSION} ; then
-	# Release with the version found. Delete it first.
-	gh release delete -y ${VERSION}
-fi
-
-# Create a new release
+# Create a new release on GitHub
 read -r -d '' RELEASE_NOTE <<EOF
 To install lium ${VERSION}, please run:
 \`\`\`
 curl -L -o /usr/local/bin/lium https://github.com/google/lium/releases/download/${VERSION}/lium && chmod +x /usr/local/bin/lium
 \`\`\`
 EOF
-gh release create ${VERSION} --target `git rev-parse HEAD` --notes "${RELEASE_NOTE}" ${TMPDIR}/release/lium
+echo "Creating release ${VERSION} on GitHub"
+gh release create ${VERSION} --target `git rev-parse HEAD` --notes "${RELEASE_NOTE}" ./target/release/lium
+
+# Create a new release on crates.io
+cargo publish


### PR DESCRIPTION
Fix the deploy script to upload statically-linked binary to GitHub and crates.io.
To upload a new release, bump up the version first, and run:
```
make release
```