### PR TITLE
deploy: Switch ~/trunk/ and ~/chromiumos/ in chroot

### DIFF
--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -72,7 +72,9 @@ pub fn run(args: &Args) -> Result<()> {
             &format!(
                 r###"
 cros-workon-{board} start {packages_str}
-~/trunk/src/scripts/update_kernel.sh {} --remote={} --ssh_port {} --remote_bootargs
+TOPDIR=~/trunk
+[ -d $TOPDIR ] || TOPDIR=~/chromiumos
+$TOPDIR/src/scripts/update_kernel.sh {} --remote={} --ssh_port {} --remote_bootargs
 "###,
                 if args.ab_update { "--ab_update" } else { "" },
                 target.host(),


### PR DESCRIPTION
Check whether ~/trunk/ exists or not, if not, use ~/chromiumos/ instead for searching update_kernel.sh script.
The `~/trunk` has been removed by https://chromium-review.googlesource.com/c/chromiumos/chromite/+/4835006