### PR TITLE
Create .gitattributes to hide generated files from the review by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/servo_power_monitor/dist/* linguist-generated=true


### PR DESCRIPTION
Mark docs/servo_power_monitor/dist/* as generated files to make the review easier. The js files under the dir should be kept checked-in for a while since it is used for github pages (will be replaced by the actions later)