### PR TITLE
Force deploy to avoid failure caused by USE mismatch warnings

### DIFF
--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -128,7 +128,7 @@ fn cros_workon_user_packages(
         chroot.run_bash_script_in_chroot(
             "deploy",
             &format!(
-                r"cros-workon-{board} start {packages_str} && cros deploy {} {user_pkgs}",
+                r"cros-workon-{board} start {packages_str} && cros deploy --force {} {user_pkgs}",
                 target.host_and_port()
             ),
             None,


### PR DESCRIPTION
Force deploy when running `cros deploy` via `lium deploy`. `cros deploy` started checking if USE flags are matched when deploying and building, and when it is not matched, it asks users to proceed or not (and... the command itself will succeed even if the stdin sends just an EOF, which is not good...), which causes a false success on the lium side. To avoid this, for now, calling `cros deploy` with `--force` flag to continue without that prompt.