### PR TITLE
lium.bash: Fix to ignore the line who has a space in the 3rd char

### DIFF
--- a/src/cmd/lium.bash
+++ b/src/cmd/lium.bash
@@ -98,7 +98,7 @@ _lium_get_options() { # current
   local otype=0
   local a b
 
-  ${cmd} --help 2>/dev/null | while read a b ;do
+  ${cmd} --help 2>/dev/null | awk '/^..[^ ]/{print $0}' | while read a b ;do
     case ${a} in
       Positional) otype=1;;
       Options:) otype=2;;


### PR DESCRIPTION
Skip the help message lines which seems not an option.
After applying this fix, lium dut shows only the options or subcommands correctly.
```
$ lium dut 
--help         discover       info           list           pull           setup          vnc
arc_info       do             kernel_config  monitor        push           shell          
```