### PR TITLE
Fix error message of arc option of vm commad

### DIFF
--- a/src/cmd/vm.rs
+++ b/src/cmd/vm.rs
@@ -249,7 +249,7 @@ fn find_betty_script(arc: &Option<String>) -> Result<String> {
         return Ok(path);
     }
 
-    bail!("betty.sh doesn't exist in {path}. Please consider specifying --repo option.")
+    bail!("betty.sh doesn't exist in {path}. Please consider specifying --arc option.")
 }
 
 fn run_betty(dir: &str, cmd: SubCommand, opts: &[&str]) -> Result<()> {


### PR DESCRIPTION
Corrected an error message when the betty script path was incorrectly specified in the vm command.