### PR TITLE
Rename repo option to cros/arc option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,26 +91,26 @@ lium servo list --json
 ### Flash
 
 ```
-lium flash --repo ${CROS_DIR} --dut ${DUT}
-lium flash --repo ${CROS_DIR} --board ${BOARD}
+lium flash --cros ${CROS_DIR} --dut ${DUT}
+lium flash --cros ${CROS_DIR} --board ${BOARD}
 ```
 
 ### Misc
 
 ```
-lium arc guest_kernel_uprev --repo /work/chromiumos_stable/
-lium build --repo /work/chromiumos_stable --board brya --packages sys-kernel/arcvm-kernel-ack-5_10
-lium build --full --repo /work/chromiumos_stable --board brya
+lium arc guest_kernel_uprev --cros /work/chromiumos_stable/
+lium build --cros /work/chromiumos_stable --board brya --packages sys-kernel/arcvm-kernel-ack-5_10
+lium build --full --cros /work/chromiumos_stable --board brya
 lium config set default_cros_checkout /work/chromiumos_stable/
 lium config show
-lium deploy --repo /work/chromiumos_stable --dut localhost:2282 --package sys-kernel/arcvm-kernel-ack-5_10 --autologin
+lium deploy --cros /work/chromiumos_stable --dut localhost:2282 --package sys-kernel/arcvm-kernel-ack-5_10 --autologin
 lium dut discover --remote kled_SOMESERIALNUMBERS1234 --v6prefix 2001:DB8::
 sudo `which lium` servo reset
-lium sync --repo /work/chromiumos_stable/ --version 14899.0.0
-lium sync --repo /work/chromiumos_stable/ --version R110-15263.0.0
+lium sync --cros /work/chromiumos_stable/ --version 14899.0.0
+lium sync --cros /work/chromiumos_stable/ --version R110-15263.0.0
 # following command needs a mirror repo which has cloned with --mirror option
-lium sync --repo /work/chromiumos_versions/R110-15248.0.0/ --version R110-15248.0.0 --reference /work/chromiumos_mirror/
-lium sync --repo /work/chromiumos_versions/R110-15248.0.0/ --version R110-15248.0.0 # you can omit --reference if the config is set
+lium sync --cros /work/chromiumos_versions/R110-15248.0.0/ --version R110-15248.0.0 --reference /work/chromiumos_mirror/
+lium sync --cros /work/chromiumos_versions/R110-15248.0.0/ --version R110-15248.0.0 # you can omit --reference if the config is set
 ```
 
 ## How to contribute

--- a/src/cmd/arc.rs
+++ b/src/cmd/arc.rs
@@ -42,10 +42,10 @@ pub fn run(args: &Args) -> Result<()> {
 pub struct ArgsGuestKernelUprev {
     /// target cros repo dir
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 }
 fn run_guest_kernel_uprev(args: &ArgsGuestKernelUprev) -> Result<()> {
-    let chroot = Chroot::new(&get_repo_dir(&args.repo)?)?;
+    let chroot = Chroot::new(&get_repo_dir(&args.cros)?)?;
     chroot.run_bash_script_in_chroot(
         "arc_guest_kernel_uprev",
         r###"
@@ -79,7 +79,7 @@ git merge -m "update wip" --no-ff aosp/android12-5.10-lts
 pub struct ArgsArcFlash {
     /// cros repo dir
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 
     /// ARC version (optional)
     #[argh(option)]
@@ -98,7 +98,7 @@ pub struct ArgsArcFlash {
     force: bool,
 }
 fn run_arc_flash(args: &ArgsArcFlash) -> Result<()> {
-    let repo = &get_repo_dir(&args.repo)?;
+    let repo = &get_repo_dir(&args.cros)?;
     ensure_testing_rsa_is_there()?;
     let target = &SshInfo::new(&args.dut)?;
     let mut different = false;

--- a/src/cmd/arc.rs
+++ b/src/cmd/arc.rs
@@ -43,6 +43,9 @@ pub struct ArgsGuestKernelUprev {
     /// target cros repo dir
     #[argh(option)]
     cros: Option<String>,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 fn run_guest_kernel_uprev(args: &ArgsGuestKernelUprev) -> Result<()> {
     let chroot = Chroot::new(&get_repo_dir(&args.cros)?)?;
@@ -96,6 +99,9 @@ pub struct ArgsArcFlash {
     /// force flash
     #[argh(switch)]
     force: bool,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 fn run_arc_flash(args: &ArgsArcFlash) -> Result<()> {
     let repo = &get_repo_dir(&args.cros)?;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -45,6 +45,9 @@ pub struct Args {
     /// do full build (build_packages + build_image)
     #[argh(switch)]
     full: bool,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 #[tracing::instrument(level = "trace")]
 pub fn run(args: &Args) -> Result<()> {

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -17,7 +17,7 @@ use tracing::info;
 pub struct Args {
     /// target cros repo dir
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 
     /// target board
     #[argh(option)]
@@ -50,7 +50,7 @@ pub struct Args {
 pub fn run(args: &Args) -> Result<()> {
     let board = &args.board;
     let use_flags = &args.use_flags;
-    let chroot = Chroot::new(&get_repo_dir(&args.repo)?)?;
+    let chroot = Chroot::new(&get_repo_dir(&args.cros)?)?;
     if !args.skip_setup {
         chroot.run_bash_script_in_chroot(
             "board_setup",

--- a/src/cmd/chroot.rs
+++ b/src/cmd/chroot.rs
@@ -16,7 +16,7 @@ use lium::repo::get_repo_dir;
 pub struct Args {
     /// target cros repo dir
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
     /// DUT env var in chroot
     #[argh(option)]
     dut: Option<String>,
@@ -29,7 +29,7 @@ pub struct Args {
 }
 #[tracing::instrument(level = "trace")]
 pub fn run(args: &Args) -> Result<()> {
-    let repo = get_repo_dir(&args.repo)?;
+    let repo = get_repo_dir(&args.cros)?;
     let mut additional_args = Vec::new();
     if let Some(dut) = &args.dut {
         let dut = SshInfo::new(dut)?;

--- a/src/cmd/chroot.rs
+++ b/src/cmd/chroot.rs
@@ -26,6 +26,9 @@ pub struct Args {
     /// if specified, run the command in chroot and exit.
     #[argh(option)]
     cmd: Option<String>,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 #[tracing::instrument(level = "trace")]
 pub fn run(args: &Args) -> Result<()> {

--- a/src/cmd/cl.rs
+++ b/src/cmd/cl.rs
@@ -41,7 +41,7 @@ pub fn run(args: &Args) -> Result<()> {
 pub struct ArgsPick {
     /// target cros repo dir
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 
     /// dir to run git commands, relative to cros checkout (e.g.
     /// src/platform/crosvm)
@@ -60,7 +60,7 @@ fn run_pick(args: &ArgsPick) -> Result<()> {
     let cl_suffix = &cl[cl.len() - 2..];
     let patchset = &capture["patchset"];
     let dir = &args.dir;
-    let chroot = Chroot::new(&get_repo_dir(&args.repo)?)?;
+    let chroot = Chroot::new(&get_repo_dir(&args.cros)?)?;
     chroot.run_bash_script_in_chroot(
         "checkout",
         &format!(

--- a/src/cmd/cl.rs
+++ b/src/cmd/cl.rs
@@ -51,6 +51,9 @@ pub struct ArgsPick {
     /// CLs to checkout (e.g. "4196467", "4196467/2")
     #[argh(positional)]
     cl: String,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 fn run_pick(args: &ArgsPick) -> Result<()> {
     let capture = RE_GERRIT_CL

--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -41,6 +41,9 @@ pub struct Args {
     /// use ab_update for kernel package
     #[argh(switch)]
     ab_update: bool,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 
 #[tracing::instrument(level = "trace")]

--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -24,7 +24,7 @@ static RE_CROS_KERNEL: Lazy<Regex> = Lazy::new(|| Regex::new("chromeos-kernel-")
 pub struct Args {
     /// target cros repo dir
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 
     /// a DUT identifier (e.g. 127.0.0.1, localhost:2222)
     #[argh(option)]
@@ -60,7 +60,7 @@ pub fn run(args: &Args) -> Result<()> {
 
     let board = target.get_board()?;
     let packages_str = args.packages.join(" ");
-    let chroot = Chroot::new(&get_repo_dir(&args.repo)?)?;
+    let chroot = Chroot::new(&get_repo_dir(&args.cros)?)?;
 
     let kernel_pkg = extract_kernel_pkg(&args.packages)?;
 

--- a/src/cmd/dut.rs
+++ b/src/cmd/dut.rs
@@ -715,6 +715,9 @@ struct ArgsDutList {
     /// update the DUT list and show their status
     #[argh(switch)]
     update: bool,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 fn run_dut_list(args: &ArgsDutList) -> Result<()> {
     if args.clear {

--- a/src/cmd/dut.rs
+++ b/src/cmd/dut.rs
@@ -547,7 +547,7 @@ struct ArgsSetup {
     serial: Option<String>,
     /// cros repo dir to use
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
     /// do ccd open only
     #[argh(switch)]
     open_ccd: bool,
@@ -571,7 +571,7 @@ struct ArgsSetup {
     check_ssh: bool,
 }
 fn run_setup(args: &ArgsSetup) -> Result<()> {
-    let repo = get_repo_dir(&args.repo)?;
+    let repo = get_repo_dir(&args.cros)?;
     let servo = if let Some(serial) = &args.serial {
         let list = ServoList::discover()?;
         list.find_by_serial(serial)

--- a/src/cmd/flash.rs
+++ b/src/cmd/flash.rs
@@ -82,7 +82,7 @@ pub struct Args {
 
     /// target cros repo dir
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 
     /// target BOARD
     #[argh(option)]
@@ -112,7 +112,7 @@ pub struct Args {
 pub fn run(args: &Args) -> Result<()> {
     // repo path is needed since cros flash outside chroot only works within the
     // cros checkout
-    let repo = &get_repo_dir(&args.repo)?;
+    let repo = &get_repo_dir(&args.cros)?;
 
     let image_path = if let Some(image) = &args.image {
         // If --image is specified, use the local file

--- a/src/cmd/flash.rs
+++ b/src/cmd/flash.rs
@@ -107,6 +107,9 @@ pub struct Args {
     /// flash image with rootfs verification (disable by default)
     #[argh(switch)]
     enable_rootfs_verification: bool,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 #[tracing::instrument(level = "trace")]
 pub fn run(args: &Args) -> Result<()> {

--- a/src/cmd/lium.bash
+++ b/src/cmd/lium.bash
@@ -141,7 +141,7 @@ _lium_get_options() { # current
 _lium() { # command current prev
   local cur=$2
   local prev=$3
-  local dir_opts="--repo --dir --dest"
+  local dir_opts="--repo --dir --dest --cros --arc"
   local file_opts="--image"
   local todo_opts="--version --workon"
   local servo_serial_opts="--serial --servo"

--- a/src/cmd/lium.bash
+++ b/src/cmd/lium.bash
@@ -141,7 +141,7 @@ _lium_get_options() { # current
 _lium() { # command current prev
   local cur=$2
   local prev=$3
-  local dir_opts="--repo --dir --dest --cros --arc"
+  local dir_opts="--dir --dest --cros --arc"
   local file_opts="--image"
   local todo_opts="--version --workon"
   local servo_serial_opts="--serial --servo"

--- a/src/cmd/packages.rs
+++ b/src/cmd/packages.rs
@@ -39,7 +39,7 @@ pub fn run(args: &Args) -> Result<()> {
 pub struct ArgsList {
     /// target cros repo directory
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 
     /// target board (default: host)
     #[argh(option)]
@@ -87,7 +87,7 @@ fn run_packages_list(args: &ArgsList) -> Result<()> {
         return print_cached_packages(&filter, board);
     }
 
-    update_cached_packages(&get_repo_dir(&args.repo)?, board)?;
+    update_cached_packages(&get_repo_dir(&args.cros)?, board)?;
 
     print_cached_packages(&filter, board)
 }

--- a/src/cmd/packages.rs
+++ b/src/cmd/packages.rs
@@ -52,6 +52,9 @@ pub struct ArgsList {
     /// glob pattern of the packages
     #[argh(positional)]
     packages: Option<String>,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 
 fn print_cached_packages(filter: &Pattern, board: &str) -> Result<()> {

--- a/src/cmd/servo.rs
+++ b/src/cmd/servo.rs
@@ -168,7 +168,7 @@ pub fn run_list(args: &ArgsList) -> Result<()> {
 pub struct ArgsControl {
     /// path to chromiumos source checkout
     #[argh(option)]
-    repo: String,
+    cros: String,
     /// a servo serial number. To list available servos, run `lium servo list`
     #[argh(option)]
     serial: String,
@@ -177,7 +177,7 @@ pub struct ArgsControl {
     args: Vec<String>,
 }
 pub fn run_control(args: &ArgsControl) -> Result<()> {
-    let chroot = Chroot::new(&args.repo)?;
+    let chroot = Chroot::new(&args.cros)?;
     let servod = ServodConnection::from_serial(&args.serial)
         .or_else(|_| LocalServo::from_serial(&args.serial)?.start_servod(&chroot))?;
     let output = servod.run_dut_control(&chroot, &args.args)?;

--- a/src/cmd/servo.rs
+++ b/src/cmd/servo.rs
@@ -175,6 +175,9 @@ pub struct ArgsControl {
     /// arguments to pass to dut_control command
     #[argh(positional)]
     args: Vec<String>,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 pub fn run_control(args: &ArgsControl) -> Result<()> {
     let chroot = Chroot::new(&args.cros)?;

--- a/src/cmd/sync.rs
+++ b/src/cmd/sync.rs
@@ -52,6 +52,9 @@ pub struct Args {
     /// output repo sync log as it is
     #[argh(switch)]
     verbose: bool,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 
 #[tracing::instrument(level = "trace")]

--- a/src/cmd/sync.rs
+++ b/src/cmd/sync.rs
@@ -29,8 +29,9 @@ pub struct Args {
     #[argh(option)]
     cros: Option<String>,
 
-    /// target android repo dir. --version will be tm or rvc. Only one of --cros
-    /// or --arc can be used.
+    /// target android repo dir. If omitted, current directory will be used.
+    /// When this flag is specified, --version option can be the branch name to
+    /// sync to.
     #[argh(option)]
     arc: Option<String>,
 
@@ -55,16 +56,10 @@ pub struct Args {
 
 #[tracing::instrument(level = "trace")]
 pub fn run(args: &Args) -> Result<()> {
-    let is_arc = if args.cros.is_some() {
-        if args.arc.is_some() {
-            bail!("Only one of --cros or --arc can be specified.");
-        } else {
-            false
-        }
-    } else if args.arc.is_some() {
-        true
-    } else {
-        bail!("Please specify either --cros or --arc.");
+    let is_arc = match (&args.cros, &args.arc) {
+        (Some(_), None) => false,
+        (None, Some(_)) => true,
+        _ => bail!("Please specify either --cros or --arc."),
     };
 
     let version = extract_version(args, &is_arc)?;

--- a/src/cmd/sync.rs
+++ b/src/cmd/sync.rs
@@ -27,7 +27,7 @@ use tracing::warn;
 pub struct Args {
     /// target cros repo dir. If omitted, current directory will be used.
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 
     /// path to a local reference repo to speedup syncing.
     #[argh(option)]
@@ -55,7 +55,7 @@ pub struct Args {
 #[tracing::instrument(level = "trace")]
 pub fn run(args: &Args) -> Result<()> {
     let version = extract_version(args)?;
-    let repo = get_cros_dir_unchecked(&args.repo)?;
+    let repo = get_cros_dir_unchecked(&args.cros)?;
 
     // Inform user of sync information.
     info!(

--- a/src/cmd/tast.rs
+++ b/src/cmd/tast.rs
@@ -60,6 +60,9 @@ pub struct ArgsList {
     /// only show cached list
     #[argh(switch)]
     cached: bool,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 
 fn print_cached_tests_in_bundle(filter: &Pattern, bundle: &str) -> Result<()> {
@@ -160,6 +163,9 @@ pub struct ArgsRun {
     /// test name or pattern
     #[argh(positional)]
     tests: String,
+
+    #[argh(option, hidden_help)]
+    repo: Option<String>,
 }
 
 fn bundle_has_test(bundle: &str, filter: &Pattern) -> bool {

--- a/src/cmd/tast.rs
+++ b/src/cmd/tast.rs
@@ -47,7 +47,7 @@ pub fn run(args: &Args) -> Result<()> {
 pub struct ArgsList {
     /// target cros repo directory
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 
     /// target DUT
     #[argh(option)]
@@ -133,7 +133,7 @@ fn run_tast_list(args: &ArgsList) -> Result<()> {
             .as_ref()
             .expect("Test name is not cached. Please rerun with --dut <DUT>");
 
-        update_cached_tests(&bundles, dut, &get_repo_dir(&args.repo)?)?;
+        update_cached_tests(&bundles, dut, &get_repo_dir(&args.cros)?)?;
     }
 
     print_cached_tests(&filter, &bundles)?;
@@ -147,7 +147,7 @@ fn run_tast_list(args: &ArgsList) -> Result<()> {
 pub struct ArgsRun {
     /// target cros repo directory
     #[argh(option)]
-    repo: Option<String>,
+    cros: Option<String>,
 
     /// target DUT
     #[argh(option)]
@@ -194,7 +194,7 @@ fn run_test_with_bundle(
 fn run_tast_run(args: &ArgsRun) -> Result<()> {
     ensure_testing_rsa_is_there()?;
     let filter = Pattern::new(&args.tests)?;
-    let repodir = get_repo_dir(&args.repo)?;
+    let repodir = get_repo_dir(&args.cros)?;
     let chroot = Chroot::new(&repodir)?;
     let ssh = SshInfo::new(&args.dut).context("failed to create SshInfo")?;
     // setup port forwarding for chroot.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 
 use std::str::FromStr;
 
+use anyhow::bail;
 use anyhow::Result;
 use tracing::trace;
 use tracing_subscriber::filter::LevelFilter;
@@ -47,6 +48,13 @@ fn main() -> Result<()> {
 
     let args_log = &std::env::args().skip(1).collect::<Vec<_>>();
     trace!("running with args: {:?}", args_log);
+
+    if args_log.contains(&"--repo".to_string()) {
+        bail!(
+            "--repo option was renamed to --cros/--arc option. `lium {} --help` has more details.",
+            args_log[0]
+        );
+    }
 
     cmd::run(&args)
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -224,7 +224,7 @@ fn ensure_is_cros_dir(path: &str) -> Result<()> {
     }
 
     Err(anyhow!(
-        "{path} is not a Chrom(e|ium) OS checkout. Please consider specifying --repo option."
+        "{path} is not a Chrom(e|ium) OS checkout. Please consider specifying --cros option."
     ))
 }
 


### PR DESCRIPTION
- Rename the `--repo` option to specify the directory path
- Use the `--cros` option for ChromeOS paths and the `--arc` option for Android paths