### PR TITLE
Support acloud in vm command

### DIFF
--- a/src/cmd/vm.rs
+++ b/src/cmd/vm.rs
@@ -209,25 +209,25 @@ pub struct ArgsStart {
     #[argh(option)]
     vm_image: Option<String>,
 
-    /// for acloud. Launch a cloud based VM instance. It is false by default.  
+    /// for acloudw. Launch a cloud based VM instance. It is false by default.  
     #[argh(switch)]
     acloud: bool,
 
-    /// for acloud. The Android branch. It is required if --acloud is
+    /// for acloudw. The Android branch. It is required if --acloud is
     /// specified.
     #[argh(option)]
     branch: Option<String>,
 
-    /// for acloud. The Android Build ID. It is required if --acloud is
+    /// for acloudw. The Android Build ID. It is required if --acloud is
     /// specified.
     #[argh(option)]
     build_id: Option<String>,
 
-    /// for acloud. Select ARC-container, not ARCVM. It is false by default.
+    /// for acloudw. Select ARC-container, not ARCVM. It is false by default.
     #[argh(switch)]
     container: bool,
 
-    /// extra arguments to pass to betty.sh or acloud. You can pass other
+    /// extra arguments to pass to betty.sh or acloudw. You can pass other
     /// options like --extra-args "options".
     #[argh(option)]
     extra_args: Option<String>,
@@ -235,7 +235,7 @@ pub struct ArgsStart {
 
 fn run_start(args: &ArgsStart) -> Result<()> {
     if args.acloud {
-        run_acloud(args)?;
+        run_acloudw(args)?;
     } else {
         run_betty_start(args)?;
 
@@ -246,17 +246,17 @@ fn run_start(args: &ArgsStart) -> Result<()> {
     Ok(())
 }
 
-fn run_acloud(args: &ArgsStart) -> Result<()> {
+fn run_acloudw(args: &ArgsStart) -> Result<()> {
     let branch = args
         .branch
         .clone()
-        .ok_or(anyhow!("--branch option is required when using acloud"))?;
+        .ok_or(anyhow!("--branch option is required when using acloudw"))?;
     let git_branch = format!("git_{branch}");
 
     let build_id = args
         .build_id
         .clone()
-        .ok_or(anyhow!("--build-id option is required when using acloud"))?;
+        .ok_or(anyhow!("--build-id option is required when using acloudw"))?;
     let re = regex!(r"^\d+$");
     if !re.is_match(&build_id) {
         bail!("--build-id must be a digit.");
@@ -265,11 +265,11 @@ fn run_acloud(args: &ArgsStart) -> Result<()> {
     let config = Config::read()?;
 
     let cmd_path = config
-        .acloud_cmd_path()
-        .context("Please configure acloud_cmd_path")?;
+        .acloudw_cmd_path()
+        .context("Please configure acloudw_cmd_path")?;
     let config_path = config
-        .acloud_config_path()
-        .context("Please configure acloud_config_path")?;
+        .acloudw_config_path()
+        .context("Please configure acloudw_config_path")?;
     let target = get_target_name(&config, args.container, &branch)?;
     let cheeps = get_cheeps_image_name(&config, args.container, &branch)?;
     let betty = get_betty_image_name(&config, args.container, &branch)?;
@@ -295,7 +295,7 @@ fn run_acloud(args: &ArgsStart) -> Result<()> {
         options.extend_from_slice(&[extra_args]);
     }
 
-    run_acloud_cmd(&options)
+    run_acloudw_cmd(&options)
 }
 
 fn get_target_name(config: &Config, is_container: bool, branch: &str) -> Result<String> {
@@ -345,7 +345,7 @@ fn get_cheeps_image_name(config: &Config, is_container: bool, branch: &str) -> R
     Ok(cheeps)
 }
 
-fn run_acloud_cmd(opts: &[&str]) -> Result<()> {
+fn run_acloudw_cmd(opts: &[&str]) -> Result<()> {
     let config = Config::read()?;
     let internal_auth_cmd = config
         .is_internal_auth_valid()
@@ -357,18 +357,18 @@ fn run_acloud_cmd(opts: &[&str]) -> Result<()> {
         bail!("{:#?}", internal_auth);
     }
 
-    let acloud_script = opts.join(" ");
-    info!("Running `{acloud_script}`...");
+    let acloudw_script = opts.join(" ");
+    info!("Running `{acloudw_script}`...");
     let mut cmd = Command::new("bash")
         .arg("-c")
-        .arg(acloud_script)
+        .arg(acloudw_script)
         .spawn()
-        .context("Failed to execute acloud")?;
+        .context("Failed to execute acloudw")?;
 
-    let result = cmd.wait().context("Failed to wait for acloud")?;
+    let result = cmd.wait().context("Failed to wait for acloudw")?;
 
     if !result.success() {
-        error!("acloud failed")
+        error!("acloudw failed")
     }
 
     Ok(())

--- a/src/cmd/vm.rs
+++ b/src/cmd/vm.rs
@@ -310,7 +310,7 @@ fn get_target_name(config: &Config, is_container: bool, branch: &str) -> Result<
     };
 
     Ok(config
-        .android_target()
+        .android_target_for_vm_type()
         .get(vm_type)
         .context(
             "Config android_target is required when using acloudw. For internal users, please \
@@ -324,7 +324,7 @@ fn get_betty_image_name(config: &Config, is_container: bool, branch: &str) -> Re
         return Ok("".to_string());
     }
     let cmd = config
-        .arc_vm_betty_image()
+        .arc_vm_betty_image_for_branch()
         .get(branch)
         .context(
             "Config arc_vm_betty_image is not set. For internal users, please configure betty \
@@ -339,7 +339,7 @@ fn get_betty_image_name(config: &Config, is_container: bool, branch: &str) -> Re
 fn get_cheeps_image_name(config: &Config, is_container: bool, branch: &str) -> Result<String> {
     let cmd = if is_container {
         config
-            .arc_container_cheeps_image()
+            .arc_container_cheeps_image_for_branch()
             .get(branch)
             .context(
                 "Config arc_container_cheeps_image is not set. For internal users, please \

--- a/src/cmd/vm.rs
+++ b/src/cmd/vm.rs
@@ -253,6 +253,7 @@ fn run_acloudw(args: &ArgsStart) -> Result<()> {
         .ok_or(anyhow!("--branch option is required when using acloudw"))?;
     let git_branch = format!("git_{branch}");
 
+    // b/314731302 use the Android API to get this programmatically if not specified
     let build_id = args
         .build_id
         .clone()

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,34 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     is_internal: Option<bool>,
+    /// This config option checks if internal authentication valid
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    is_internal_auth_valid: Option<String>,
+    /// This config option is path to acloud command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    acloud_cmd_path: Option<String>,
+    /// This config option is path to acloud config.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    acloud_config_path: Option<String>,
+    /// This config option is a lunch target for each Android branch.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
+    android_target: HashMap<String, String>,
+    /// This config option is a cheeps image name for ARCVM.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    arc_vm_cheeps_image: Option<String>,
+    /// This config option is a betty image name for ARCVM.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
+    arc_vm_betty_image: HashMap<String, String>,
+    /// This config option is a cheeps image name for ARC-container.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
+    arc_container_cheeps_image: HashMap<String, String>,
 }
 static CONFIG_FILE_NAME: &str = "config.json";
 impl Config {
@@ -157,6 +185,54 @@ impl Config {
                 }
                 self.is_internal = Some(values[0].as_ref().parse::<bool>().unwrap());
             }
+            "is_internal_auth_valid" => {
+                if values.len() != 1 {
+                    bail!("{key} only takes 1 params");
+                }
+                self.is_internal_auth_valid = Some(values[0].as_ref().to_string());
+            }
+            "acloud_cmd_path" => {
+                if values.len() != 1 {
+                    bail!("{key} only takes 1 params");
+                }
+                self.acloud_cmd_path = Some(values[0].as_ref().to_string())
+            }
+            "acloud_config_path" => {
+                if values.len() != 1 {
+                    bail!("{key} only takes 1 params");
+                }
+                self.acloud_config_path = Some(values[0].as_ref().to_string())
+            }
+            "android_target" => {
+                if values.len() != 2 {
+                    bail!("{key} takes 2 parameters");
+                }
+                let branch = values[0].as_ref().to_string();
+                let target = values[1].as_ref().to_string();
+                self.android_target.insert(branch, target);
+            }
+            "arc_vm_cheeps_image" => {
+                if values.len() != 1 {
+                    bail!("{key} only takes 1 params");
+                }
+                self.arc_vm_cheeps_image = Some(values[0].as_ref().to_string());
+            }
+            "arc_vm_betty_image" => {
+                if values.len() != 2 {
+                    bail!("{key} takes 2 parameters");
+                }
+                let branch = values[0].as_ref().to_string();
+                let target = values[1].as_ref().to_string();
+                self.arc_vm_betty_image.insert(branch, target);
+            }
+            "arc_container_cheeps_image" => {
+                if values.len() != 2 {
+                    bail!("{key} takes 2 parameters");
+                }
+                let branch = values[0].as_ref().to_string();
+                let target = values[1].as_ref().to_string();
+                self.arc_container_cheeps_image.insert(branch, target);
+            }
             _ => bail!("config key {key} is not valid"),
         }
         self.write()
@@ -190,6 +266,21 @@ impl Config {
             "is_internal" => {
                 self.is_internal = None;
             }
+            "is_internal_auth_valid" => {
+                self.is_internal_auth_valid = None;
+            }
+            "acloud_cmd_path" => {
+                self.acloud_cmd_path = None;
+            }
+            "acloud_config_path" => {
+                self.acloud_config_path = None;
+            }
+            "android_target" => self.android_target.clear(),
+            "arc_vm_cheeps_image" => {
+                self.arc_vm_cheeps_image = None;
+            }
+            "arc_vm_betty_image" => self.arc_vm_betty_image.clear(),
+            "arc_container_cheeps_image" => self.arc_container_cheeps_image.clear(),
             _ => bail!("lium config clear for '{key}' is not implemented"),
         }
         self.write()?;
@@ -219,5 +310,26 @@ impl Config {
     }
     pub fn is_internal(&self) -> bool {
         self.is_internal.unwrap_or(false)
+    }
+    pub fn is_internal_auth_valid(&self) -> Option<String> {
+        self.is_internal_auth_valid.clone()
+    }
+    pub fn acloud_cmd_path(&self) -> Option<String> {
+        self.acloud_cmd_path.clone()
+    }
+    pub fn acloud_config_path(&self) -> Option<String> {
+        self.acloud_config_path.clone()
+    }
+    pub fn android_target(&self) -> &HashMap<String, String> {
+        &self.android_target
+    }
+    pub fn arc_vm_cheeps_image(&self) -> Option<String> {
+        self.arc_vm_cheeps_image.clone()
+    }
+    pub fn arc_vm_betty_image(&self) -> &HashMap<String, String> {
+        &self.arc_vm_betty_image
+    }
+    pub fn arc_container_cheeps_image(&self) -> &HashMap<String, String> {
+        &self.arc_container_cheeps_image
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,14 +77,14 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     is_internal_auth_valid: Option<String>,
-    /// This config option is path to acloud command.
+    /// This config option is path to acloudw command.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    acloud_cmd_path: Option<String>,
-    /// This config option is path to acloud config.
+    acloudw_cmd_path: Option<String>,
+    /// This config option is path to acloudw config.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    acloud_config_path: Option<String>,
+    acloudw_config_path: Option<String>,
     /// This config option is a lunch target for each Android branch.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
@@ -191,17 +191,17 @@ impl Config {
                 }
                 self.is_internal_auth_valid = Some(values[0].as_ref().to_string());
             }
-            "acloud_cmd_path" => {
+            "acloudw_cmd_path" => {
                 if values.len() != 1 {
                     bail!("{key} only takes 1 params");
                 }
-                self.acloud_cmd_path = Some(values[0].as_ref().to_string())
+                self.acloudw_cmd_path = Some(values[0].as_ref().to_string())
             }
-            "acloud_config_path" => {
+            "acloudw_config_path" => {
                 if values.len() != 1 {
                     bail!("{key} only takes 1 params");
                 }
-                self.acloud_config_path = Some(values[0].as_ref().to_string())
+                self.acloudw_config_path = Some(values[0].as_ref().to_string())
             }
             "android_target" => {
                 if values.len() != 2 {
@@ -269,11 +269,11 @@ impl Config {
             "is_internal_auth_valid" => {
                 self.is_internal_auth_valid = None;
             }
-            "acloud_cmd_path" => {
-                self.acloud_cmd_path = None;
+            "acloudw_cmd_path" => {
+                self.acloudw_cmd_path = None;
             }
-            "acloud_config_path" => {
-                self.acloud_config_path = None;
+            "acloudw_config_path" => {
+                self.acloudw_config_path = None;
             }
             "android_target" => self.android_target.clear(),
             "arc_vm_cheeps_image" => {
@@ -314,11 +314,11 @@ impl Config {
     pub fn is_internal_auth_valid(&self) -> Option<String> {
         self.is_internal_auth_valid.clone()
     }
-    pub fn acloud_cmd_path(&self) -> Option<String> {
-        self.acloud_cmd_path.clone()
+    pub fn acloudw_cmd_path(&self) -> Option<String> {
+        self.acloudw_cmd_path.clone()
     }
-    pub fn acloud_config_path(&self) -> Option<String> {
-        self.acloud_config_path.clone()
+    pub fn acloudw_config_path(&self) -> Option<String> {
+        self.acloudw_config_path.clone()
     }
     pub fn android_target(&self) -> &HashMap<String, String> {
         &self.android_target

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,7 @@ pub struct Config {
     /// the internal lium-installer.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
-    android_target: HashMap<String, String>,
+    android_target_for_vm_type: HashMap<String, String>,
     /// Command to get cheeps image name for ARCVM. It is set by the internal
     /// lium-installer.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -100,12 +100,12 @@ pub struct Config {
     /// It is set by the internal lium-installer.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
-    arc_vm_betty_image: HashMap<String, String>,
+    arc_vm_betty_image_for_branch: HashMap<String, String>,
     /// Key: Android branch, value: command to get cheeps image name for
     /// ARC-container. It is set by the internal lium-installer.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
-    arc_container_cheeps_image: HashMap<String, String>,
+    arc_container_cheeps_image_for_branch: HashMap<String, String>,
 }
 static CONFIG_FILE_NAME: &str = "config.json";
 impl Config {
@@ -208,13 +208,13 @@ impl Config {
                 }
                 self.acloudw_config_path = Some(values[0].as_ref().to_string());
             }
-            "android_target" => {
+            "android_target_for_vm_type" => {
                 if values.len() != 2 {
                     bail!("{key} takes 2 parameters");
                 }
                 let branch = values[0].as_ref().to_string();
                 let target = values[1].as_ref().to_string();
-                self.android_target.insert(branch, target);
+                self.android_target_for_vm_type.insert(branch, target);
             }
             "arc_vm_cheeps_image" => {
                 if values.len() != 1 {
@@ -222,21 +222,22 @@ impl Config {
                 }
                 self.arc_vm_cheeps_image = Some(values[0].as_ref().to_string());
             }
-            "arc_vm_betty_image" => {
+            "arc_vm_betty_image_for_branch" => {
                 if values.len() != 2 {
                     bail!("{key} takes 2 parameters");
                 }
                 let branch = values[0].as_ref().to_string();
                 let target = values[1].as_ref().to_string();
-                self.arc_vm_betty_image.insert(branch, target);
+                self.arc_vm_betty_image_for_branch.insert(branch, target);
             }
-            "arc_container_cheeps_image" => {
+            "arc_container_cheeps_image_for_brnach" => {
                 if values.len() != 2 {
                     bail!("{key} takes 2 parameters");
                 }
                 let branch = values[0].as_ref().to_string();
                 let target = values[1].as_ref().to_string();
-                self.arc_container_cheeps_image.insert(branch, target);
+                self.arc_container_cheeps_image_for_branch
+                    .insert(branch, target);
             }
             _ => bail!("config key {key} is not valid"),
         }
@@ -280,12 +281,14 @@ impl Config {
             "acloudw_config_path" => {
                 self.acloudw_config_path = None;
             }
-            "android_target" => self.android_target.clear(),
+            "android_target_for_vm_type" => self.android_target_for_vm_type.clear(),
             "arc_vm_cheeps_image" => {
                 self.arc_vm_cheeps_image = None;
             }
-            "arc_vm_betty_image" => self.arc_vm_betty_image.clear(),
-            "arc_container_cheeps_image" => self.arc_container_cheeps_image.clear(),
+            "arc_vm_betty_image_for_branch" => self.arc_vm_betty_image_for_branch.clear(),
+            "arc_container_cheeps_image_for_branch" => {
+                self.arc_container_cheeps_image_for_branch.clear()
+            }
             _ => bail!("lium config clear for '{key}' is not implemented"),
         }
         self.write()?;
@@ -325,16 +328,16 @@ impl Config {
     pub fn acloudw_config_path(&self) -> Option<String> {
         self.acloudw_config_path.clone()
     }
-    pub fn android_target(&self) -> &HashMap<String, String> {
-        &self.android_target
+    pub fn android_target_for_vm_type(&self) -> &HashMap<String, String> {
+        &self.android_target_for_vm_type
     }
     pub fn arc_vm_cheeps_image(&self) -> Option<String> {
         self.arc_vm_cheeps_image.clone()
     }
-    pub fn arc_vm_betty_image(&self) -> &HashMap<String, String> {
-        &self.arc_vm_betty_image
+    pub fn arc_vm_betty_image_for_branch(&self) -> &HashMap<String, String> {
+        &self.arc_vm_betty_image_for_branch
     }
-    pub fn arc_container_cheeps_image(&self) -> &HashMap<String, String> {
-        &self.arc_container_cheeps_image
+    pub fn arc_container_cheeps_image_for_branch(&self) -> &HashMap<String, String> {
+        &self.arc_container_cheeps_image_for_branch
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,31 +73,36 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     is_internal: Option<bool>,
-    /// This config option checks if internal authentication valid
+    /// Command to check if internal authentication valid. It is set by the
+    /// internal lium-installer.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     is_internal_auth_valid: Option<String>,
-    /// This config option is path to acloudw command.
+    /// Path to acloudw.sh. It is set by the internal lium-installer.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     acloudw_cmd_path: Option<String>,
-    /// This config option is path to acloudw config.
+    /// Path to acloudw config file. It is set by the internal lium-installer.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     acloudw_config_path: Option<String>,
-    /// This config option is a lunch target for each Android branch.
+    /// Key: {vm, container, main}, value: Android lunch target. It is set by
+    /// the internal lium-installer.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
     android_target: HashMap<String, String>,
-    /// This config option is a cheeps image name for ARCVM.
+    /// Command to get cheeps image name for ARCVM. It is set by the internal
+    /// lium-installer.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     arc_vm_cheeps_image: Option<String>,
-    /// This config option is a betty image name for ARCVM.
+    /// Key: Android branch, value: command to get betty image name for ARCVM.
+    /// It is set by the internal lium-installer.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
     arc_vm_betty_image: HashMap<String, String>,
-    /// This config option is a cheeps image name for ARC-container.
+    /// Key: Android branch, value: command to get cheeps image name for
+    /// ARC-container. It is set by the internal lium-installer.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
     arc_container_cheeps_image: HashMap<String, String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,13 +200,13 @@ impl Config {
                 if values.len() != 1 {
                     bail!("{key} only takes 1 params");
                 }
-                self.acloudw_cmd_path = Some(values[0].as_ref().to_string())
+                self.acloudw_cmd_path = Some(values[0].as_ref().to_string());
             }
             "acloudw_config_path" => {
                 if values.len() != 1 {
                     bail!("{key} only takes 1 params");
                 }
-                self.acloudw_config_path = Some(values[0].as_ref().to_string())
+                self.acloudw_config_path = Some(values[0].as_ref().to_string());
             }
             "android_target" => {
                 if values.len() != 2 {


### PR DESCRIPTION
- Change the `lium vm start` command to launch cloud based VM instances
- Add the config options to get acloudw command parameters
- Separate the process of running betty.sh and the process of running acloudw into functions

Issue: https://github.com/google/lium/issues/87