### PR TITLE
Remove HWID from default key to add VM instance to DUT list

### DIFF
--- a/src/cmd/dut.rs
+++ b/src/cmd/dut.rs
@@ -813,15 +813,7 @@ struct ArgsDutInfo {
 fn run_dut_info(args: &ArgsDutInfo) -> Result<()> {
     let dut = &args.dut;
     let keys = if args.keys.is_empty() {
-        vec![
-            "timestamp",
-            "dut_id",
-            "hwid",
-            "release",
-            "model",
-            "serial",
-            "mac",
-        ]
+        vec!["timestamp", "dut_id", "release", "model", "serial", "mac"]
     } else {
         args.keys.iter().map(|s| s.as_str()).collect()
     };

--- a/src/dut.rs
+++ b/src/dut.rs
@@ -181,6 +181,7 @@ const CMD_GET_DEFAULT_IFACE: &str =
     r"ip route get 8.8.8.8 | sed -E 's/^.* dev ([^ ]+) .*$/\1/' | head -n 1";
 
 // Only keys that are always available can be listed here
+// We should consider the value of these keys if DUT is a VM
 const DEFAULT_DUT_INFO_KEYS: [&str; 7] = [
     "timestamp",
     "dut_id",

--- a/src/dut.rs
+++ b/src/dut.rs
@@ -143,6 +143,7 @@ lazy_static! {
     static ref DUT_ATTRIBUTE_CMDS: HashMap<&'static str, &'static str> = {
         let mut m: HashMap<&'static str, &'static str> = HashMap::new();
         m.insert("board", r"cat /etc/lsb-release | grep CHROMEOS_RELEASE_BOARD | cut -d '=' -f 2 | cut -d '-' -f 1");
+        // VM instances do not have a valid HWID.
         m.insert("hwid", r"crossystem hwid");
         m.insert("arch", r"crossystem arch");
         m.insert("serial", r"vpd -g serial_number");
@@ -180,10 +181,9 @@ const CMD_GET_DEFAULT_IFACE: &str =
     r"ip route get 8.8.8.8 | sed -E 's/^.* dev ([^ ]+) .*$/\1/' | head -n 1";
 
 // Only keys that are always available can be listed here
-const DEFAULT_DUT_INFO_KEYS: [&str; 8] = [
+const DEFAULT_DUT_INFO_KEYS: [&str; 7] = [
     "timestamp",
     "dut_id",
-    "hwid",
     "release",
     "model",
     "serial",

--- a/src/dut.rs
+++ b/src/dut.rs
@@ -143,7 +143,7 @@ lazy_static! {
     static ref DUT_ATTRIBUTE_CMDS: HashMap<&'static str, &'static str> = {
         let mut m: HashMap<&'static str, &'static str> = HashMap::new();
         m.insert("board", r"cat /etc/lsb-release | grep CHROMEOS_RELEASE_BOARD | cut -d '=' -f 2 | cut -d '-' -f 1");
-        // VM instances do not have a valid HWID.
+        // NOTE: VM instances do not have a valid HWID.
         m.insert("hwid", r"crossystem hwid");
         m.insert("arch", r"crossystem arch");
         m.insert("serial", r"vpd -g serial_number");
@@ -181,7 +181,6 @@ const CMD_GET_DEFAULT_IFACE: &str =
     r"ip route get 8.8.8.8 | sed -E 's/^.* dev ([^ ]+) .*$/\1/' | head -n 1";
 
 // Only keys that are always available can be listed here
-// We should consider the value of these keys if DUT is a VM
 const DEFAULT_DUT_INFO_KEYS: [&str; 7] = [
     "timestamp",
     "dut_id",


### PR DESCRIPTION
Remove HWID from the list of the default DUT info key to add VM instances (e.g. betty VM) to the DUT list