### PR TITLE
Add tab completion of branch name

### DIFF
--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -4,9 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+use anyhow::bail;
 use anyhow::Result;
 use argh::FromArgs;
 use lium::config::Config;
+use serde_json::json;
 
 #[derive(FromArgs, PartialEq, Debug)]
 /// configure lium
@@ -66,9 +68,23 @@ fn run_set(args: &ArgsSet) -> Result<()> {
 #[derive(FromArgs, PartialEq, Debug)]
 /// Show config variables
 #[argh(subcommand, name = "show")]
-pub struct ArgsShow {}
-fn run_show(_args: &ArgsShow) -> Result<()> {
+pub struct ArgsShow {
+    /// key of a config
+    #[argh(option)]
+    key: Option<String>,
+}
+fn run_show(args: &ArgsShow) -> Result<()> {
     let config = Config::read()?;
-    println!("{}", serde_json::to_string_pretty(&config)?);
+
+    if let Some(key) = &args.key {
+        let value = match json!(&config).get(key) {
+            Some(v) => v.to_string(),
+            None => bail!("Failed to get a config value of {key}"),
+        };
+        println!("{}", value);
+    } else {
+        println!("{}", serde_json::to_string_pretty(&config)?);
+    }
+
     Ok(())
 }

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -70,7 +70,7 @@ fn run_set(args: &ArgsSet) -> Result<()> {
 #[argh(subcommand, name = "show")]
 pub struct ArgsShow {
     /// key of a config
-    #[argh(option)]
+    #[argh(positional)]
     key: Option<String>,
 }
 fn run_show(args: &ArgsShow) -> Result<()> {

--- a/src/cmd/lium.bash
+++ b/src/cmd/lium.bash
@@ -72,6 +72,10 @@ _lium_get_boards() {
   ${COMP_WORDS[0]} board list --cached 2>/dev/null | cut -f 1
 }
 
+_lium_get_branches() {
+  ${COMP_WORDS[0]} config show --key android_branches 2>/dev/null | sed -e 's/[]["]//g' | sed -e 's/,/ /g'  
+}
+
 _lium_get_dut_actions() {
   lium dut do --list-actions 2>/dev/null
 }
@@ -161,6 +165,9 @@ _lium() { # command current prev
   elif [ x"$prev" = x"--board" ]; then
     local BOARDS=`_lium_get_boards`
     COMPREPLY=($(compgen -W "${BOARDS}" -- $cur))
+  elif [ x"$prev" = x"--branch"]
+    local BRANCHES=`_lium_get_branches`
+    COMPREPLY=($(compgen -W "${BRANCHES}" -- $cur))
   elif _lium_arg_included ${prev} ${servo_serial_opts}; then
     local DUTS=`_lium_get_servos`
     COMPREPLY=($(compgen -W "${DUTS}" -- $cur))

--- a/src/cmd/lium.bash
+++ b/src/cmd/lium.bash
@@ -165,7 +165,7 @@ _lium() { # command current prev
   elif [ x"$prev" = x"--board" ]; then
     local BOARDS=`_lium_get_boards`
     COMPREPLY=($(compgen -W "${BOARDS}" -- $cur))
-  elif [ x"$prev" = x"--branch"]
+  elif [ x"$prev" = x"--branch"]; then 
     local BRANCHES=`_lium_get_branches`
     COMPREPLY=($(compgen -W "${BRANCHES}" -- $cur))
   elif _lium_arg_included ${prev} ${servo_serial_opts}; then

--- a/src/cmd/lium.bash
+++ b/src/cmd/lium.bash
@@ -73,7 +73,7 @@ _lium_get_boards() {
 }
 
 _lium_get_branches() {
-  ${COMP_WORDS[0]} config show --key android_branches 2>/dev/null | sed -e 's/[]["]//g' | sed -e 's/,/ /g'  
+  ${COMP_WORDS[0]} config show android_branches 2>/dev/null | sed -e 's/[]["]//g' | sed -e 's/,/ /g'  
 }
 
 _lium_get_dut_actions() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,9 @@ impl SshOverride {
 pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
+    android_branches: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     android_manifest_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -132,6 +135,11 @@ impl Config {
     }
     pub fn set<K: AsRef<str>>(&mut self, key: &str, values: &[K]) -> Result<()> {
         match key {
+            "android_branches" => {
+                let branches: Vec<String> =
+                    values[0..].iter().map(|s| s.as_ref().to_string()).collect();
+                self.android_branches = Some(branches);
+            }
             "android_manifest_url" => {
                 if values.len() != 1 {
                     bail!("{key} only takes 1 params");
@@ -245,6 +253,9 @@ impl Config {
     }
     pub fn clear(&mut self, key: &str) -> Result<()> {
         match key {
+            "android_branches" => {
+                self.android_branches = None;
+            }
             "android_manifest_url" => {
                 self.android_manifest_url = None;
             }
@@ -293,6 +304,13 @@ impl Config {
         }
         self.write()?;
         Ok(())
+    }
+    pub fn android_branches(&self) -> Vec<&str> {
+        if let Some(branches) = &self.android_branches {
+            branches.iter().map(|s| s as &str).collect()
+        } else {
+            Vec::new()
+        }
     }
     pub fn tast_bundles(&self) -> Vec<&str> {
         if let Some(bundles) = &self.tast_bundles {


### PR DESCRIPTION
- Add the `--branch` subcommand
- Add tab completion of Android branch name
- Use it when the `--branch` option is specified (e.g. `lium vm start` command)