### PR TITLE
Call `adb connect` before calling `adb logcat`

### DIFF
--- a/src/cmd/arc.rs
+++ b/src/cmd/arc.rs
@@ -177,6 +177,10 @@ pub struct ArgsLogcat {
 }
 fn run_logcat(args: &ArgsLogcat) -> Result<()> {
     let remote = SshInfo::new(&args.dut)?;
+    let devices = remote.run_cmd_stdio("adb devices")?;
+    if !devices.contains("localhost:22") {
+        remote.run_cmd_piped(&["adb", "connect", "localhost:22"])?;
+    }
     remote.run_cmd_piped(&["adb", "logcat"])?;
     Ok(())
 }


### PR DESCRIPTION
adb has to connect to the Android VM before calling logcat to get the result.

TEST=Ran `lium arc logcat --dut $DUT` twice. `adb connect` was called only first time.